### PR TITLE
Normalize SKILL.md files to UTF-8 without BOM

### DIFF
--- a/.agents/skills/img_to_pdf/SKILL.md
+++ b/.agents/skills/img_to_pdf/SKILL.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: img_to_pdf
 description: Use this skill when the user wants to convert image files (jpg, png, etc.) to PDF documents. It provides a Python script to perform the conversion. It can also demonstrate the usage by setting up an example directory.
 ---

--- a/.claude/skills/img_to_pdf/SKILL.md
+++ b/.claude/skills/img_to_pdf/SKILL.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: img_to_pdf
 description: Use this skill when the user wants to convert image files (jpg, png, etc.) to PDF documents. It provides a Python script to perform the conversion. It can also demonstrate the usage by setting up an example directory.
 ---


### PR DESCRIPTION
### Motivation
- Ensure skill descriptor files are encoded as UTF-8 without a BOM so the skill loader / AI can reliably read and parse `SKILL.md` files.

### Description
- Rewrote ` .claude/skills/img_to_pdf/SKILL.md` and `.agents/skills/img_to_pdf/SKILL.md` to remove the UTF-8 BOM and normalize the files to UTF-8 while preserving content and normalizing newlines.

### Testing
- Ran Python-based checks that read files as bytes and via `encoding='utf-8-sig'` to confirm the BOM was removed and both files decode successfully as UTF-8, and those checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a1648202d48326a6e1014fcf108224)